### PR TITLE
fix(tests): update proxy env var test assertions for httpx 0.28

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -892,9 +892,10 @@ class TestLlamaAPIClient:
 
         client = DefaultHttpxClient()
 
-        mounts = tuple(client._mounts.items())
-        assert len(mounts) == 1
-        assert mounts[0][0].pattern == "https://"
+        proxy_mounts = {
+            pattern.pattern: transport for pattern, transport in client._mounts.items() if transport is not None
+        }
+        assert "https://" in proxy_mounts
 
     @pytest.mark.filterwarnings("ignore:.*deprecated.*:DeprecationWarning")
     def test_default_client_creation(self) -> None:
@@ -1778,9 +1779,10 @@ class TestAsyncLlamaAPIClient:
 
         client = DefaultAsyncHttpxClient()
 
-        mounts = tuple(client._mounts.items())
-        assert len(mounts) == 1
-        assert mounts[0][0].pattern == "https://"
+        proxy_mounts = {
+            pattern.pattern: transport for pattern, transport in client._mounts.items() if transport is not None
+        }
+        assert "https://" in proxy_mounts
 
     @pytest.mark.filterwarnings("ignore:.*deprecated.*:DeprecationWarning")
     async def test_default_client_creation(self) -> None:


### PR DESCRIPTION
## Summary
- Updates `test_proxy_environment_variables` in both sync and async client test classes
- httpx 0.28 includes default fallback mounts (None transports) alongside configured proxy transports in `_mounts`, so the old assertion `len(mounts) == 1` fails
- Now filters for non-None transports and asserts the `https://` proxy pattern exists instead of checking exact count

## Test plan
- [x] `pytest tests/test_client.py -k test_proxy_environment_variables` — both tests pass
- [x] Full test suite: 528 passed, 0 failed