### PR TITLE
fix(tests): enable API resource tests with respx mocking

### DIFF
--- a/tests/api_resources/chat/test_completions.py
+++ b/tests/api_resources/chat/test_completions.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import os
 from typing import Any, cast
 
+import httpx
 import pytest
+from respx import MockRouter
 
 from tests.utils import assert_matches_type
 from llama_api_client import LlamaAPIClient, AsyncLlamaAPIClient
@@ -17,9 +19,14 @@ base_url = os.environ.get("TEST_API_BASE_URL", "http://127.0.0.1:4010")
 class TestCompletions:
     parametrize = pytest.mark.parametrize("client", [False, True], indirect=True, ids=["loose", "strict"])
 
-    @pytest.mark.skip(reason="Prism tests are disabled")
+    @pytest.mark.respx(base_url=base_url)
     @parametrize
-    def test_method_create_overload_1(self, client: LlamaAPIClient) -> None:
+    def test_method_create_overload_1(self, client: LlamaAPIClient, respx_mock: MockRouter) -> None:
+        respx_mock.post("/chat/completions").mock(
+            return_value=httpx.Response(
+                200, json={"completion_message": {"role": "assistant", "content": "hello"}, "id": "chatcmpl-123"}
+            )
+        )
         completion = client.chat.completions.create(
             messages=[
                 {
@@ -31,9 +38,14 @@ class TestCompletions:
         )
         assert_matches_type(CreateChatCompletionResponse, completion, path=["response"])
 
-    @pytest.mark.skip(reason="Prism tests are disabled")
+    @pytest.mark.respx(base_url=base_url)
     @parametrize
-    def test_method_create_with_all_params_overload_1(self, client: LlamaAPIClient) -> None:
+    def test_method_create_with_all_params_overload_1(self, client: LlamaAPIClient, respx_mock: MockRouter) -> None:
+        respx_mock.post("/chat/completions").mock(
+            return_value=httpx.Response(
+                200, json={"completion_message": {"role": "assistant", "content": "hello"}, "id": "chatcmpl-123"}
+            )
+        )
         completion = client.chat.completions.create(
             messages=[
                 {
@@ -71,9 +83,14 @@ class TestCompletions:
         )
         assert_matches_type(CreateChatCompletionResponse, completion, path=["response"])
 
-    @pytest.mark.skip(reason="Prism tests are disabled")
+    @pytest.mark.respx(base_url=base_url)
     @parametrize
-    def test_raw_response_create_overload_1(self, client: LlamaAPIClient) -> None:
+    def test_raw_response_create_overload_1(self, client: LlamaAPIClient, respx_mock: MockRouter) -> None:
+        respx_mock.post("/chat/completions").mock(
+            return_value=httpx.Response(
+                200, json={"completion_message": {"role": "assistant", "content": "hello"}, "id": "chatcmpl-123"}
+            )
+        )
         response = client.chat.completions.with_raw_response.create(
             messages=[
                 {
@@ -89,9 +106,14 @@ class TestCompletions:
         completion = response.parse()
         assert_matches_type(CreateChatCompletionResponse, completion, path=["response"])
 
-    @pytest.mark.skip(reason="Prism tests are disabled")
+    @pytest.mark.respx(base_url=base_url)
     @parametrize
-    def test_streaming_response_create_overload_1(self, client: LlamaAPIClient) -> None:
+    def test_streaming_response_create_overload_1(self, client: LlamaAPIClient, respx_mock: MockRouter) -> None:
+        respx_mock.post("/chat/completions").mock(
+            return_value=httpx.Response(
+                200, json={"completion_message": {"role": "assistant", "content": "hello"}, "id": "chatcmpl-123"}
+            )
+        )
         with client.chat.completions.with_streaming_response.create(
             messages=[
                 {
@@ -109,9 +131,16 @@ class TestCompletions:
 
         assert cast(Any, response.is_closed) is True
 
-    @pytest.mark.skip(reason="Prism tests are disabled")
+    @pytest.mark.respx(base_url=base_url)
     @parametrize
-    def test_method_create_overload_2(self, client: LlamaAPIClient) -> None:
+    def test_method_create_overload_2(self, client: LlamaAPIClient, respx_mock: MockRouter) -> None:
+        respx_mock.post("/chat/completions").mock(
+            return_value=httpx.Response(
+                200,
+                headers={"content-type": "text/event-stream"},
+                content=b'data: {"event":{"event_type":"start","delta":{"type":"text","text":"hi"}}}\n\n',
+            )
+        )
         completion_stream = client.chat.completions.create(
             messages=[
                 {
@@ -124,9 +153,16 @@ class TestCompletions:
         )
         completion_stream.response.close()
 
-    @pytest.mark.skip(reason="Prism tests are disabled")
+    @pytest.mark.respx(base_url=base_url)
     @parametrize
-    def test_method_create_with_all_params_overload_2(self, client: LlamaAPIClient) -> None:
+    def test_method_create_with_all_params_overload_2(self, client: LlamaAPIClient, respx_mock: MockRouter) -> None:
+        respx_mock.post("/chat/completions").mock(
+            return_value=httpx.Response(
+                200,
+                headers={"content-type": "text/event-stream"},
+                content=b'data: {"event":{"event_type":"start","delta":{"type":"text","text":"hi"}}}\n\n',
+            )
+        )
         completion_stream = client.chat.completions.create(
             messages=[
                 {
@@ -164,9 +200,16 @@ class TestCompletions:
         )
         completion_stream.response.close()
 
-    @pytest.mark.skip(reason="Prism tests are disabled")
+    @pytest.mark.respx(base_url=base_url)
     @parametrize
-    def test_raw_response_create_overload_2(self, client: LlamaAPIClient) -> None:
+    def test_raw_response_create_overload_2(self, client: LlamaAPIClient, respx_mock: MockRouter) -> None:
+        respx_mock.post("/chat/completions").mock(
+            return_value=httpx.Response(
+                200,
+                headers={"content-type": "text/event-stream"},
+                content=b'data: {"event":{"event_type":"start","delta":{"type":"text","text":"hi"}}}\n\n',
+            )
+        )
         response = client.chat.completions.with_raw_response.create(
             messages=[
                 {
@@ -182,9 +225,16 @@ class TestCompletions:
         stream = response.parse()
         stream.close()
 
-    @pytest.mark.skip(reason="Prism tests are disabled")
+    @pytest.mark.respx(base_url=base_url)
     @parametrize
-    def test_streaming_response_create_overload_2(self, client: LlamaAPIClient) -> None:
+    def test_streaming_response_create_overload_2(self, client: LlamaAPIClient, respx_mock: MockRouter) -> None:
+        respx_mock.post("/chat/completions").mock(
+            return_value=httpx.Response(
+                200,
+                headers={"content-type": "text/event-stream"},
+                content=b'data: {"event":{"event_type":"start","delta":{"type":"text","text":"hi"}}}\n\n',
+            )
+        )
         with client.chat.completions.with_streaming_response.create(
             messages=[
                 {
@@ -209,9 +259,14 @@ class TestAsyncCompletions:
         "async_client", [False, True, {"http_client": "aiohttp"}], indirect=True, ids=["loose", "strict", "aiohttp"]
     )
 
-    @pytest.mark.skip(reason="Prism tests are disabled")
+    @pytest.mark.respx(base_url=base_url)
     @parametrize
-    async def test_method_create_overload_1(self, async_client: AsyncLlamaAPIClient) -> None:
+    async def test_method_create_overload_1(self, async_client: AsyncLlamaAPIClient, respx_mock: MockRouter) -> None:
+        respx_mock.post("/chat/completions").mock(
+            return_value=httpx.Response(
+                200, json={"completion_message": {"role": "assistant", "content": "hello"}, "id": "chatcmpl-123"}
+            )
+        )
         completion = await async_client.chat.completions.create(
             messages=[
                 {
@@ -223,9 +278,16 @@ class TestAsyncCompletions:
         )
         assert_matches_type(CreateChatCompletionResponse, completion, path=["response"])
 
-    @pytest.mark.skip(reason="Prism tests are disabled")
+    @pytest.mark.respx(base_url=base_url)
     @parametrize
-    async def test_method_create_with_all_params_overload_1(self, async_client: AsyncLlamaAPIClient) -> None:
+    async def test_method_create_with_all_params_overload_1(
+        self, async_client: AsyncLlamaAPIClient, respx_mock: MockRouter
+    ) -> None:
+        respx_mock.post("/chat/completions").mock(
+            return_value=httpx.Response(
+                200, json={"completion_message": {"role": "assistant", "content": "hello"}, "id": "chatcmpl-123"}
+            )
+        )
         completion = await async_client.chat.completions.create(
             messages=[
                 {
@@ -263,9 +325,16 @@ class TestAsyncCompletions:
         )
         assert_matches_type(CreateChatCompletionResponse, completion, path=["response"])
 
-    @pytest.mark.skip(reason="Prism tests are disabled")
+    @pytest.mark.respx(base_url=base_url)
     @parametrize
-    async def test_raw_response_create_overload_1(self, async_client: AsyncLlamaAPIClient) -> None:
+    async def test_raw_response_create_overload_1(
+        self, async_client: AsyncLlamaAPIClient, respx_mock: MockRouter
+    ) -> None:
+        respx_mock.post("/chat/completions").mock(
+            return_value=httpx.Response(
+                200, json={"completion_message": {"role": "assistant", "content": "hello"}, "id": "chatcmpl-123"}
+            )
+        )
         response = await async_client.chat.completions.with_raw_response.create(
             messages=[
                 {
@@ -281,9 +350,16 @@ class TestAsyncCompletions:
         completion = await response.parse()
         assert_matches_type(CreateChatCompletionResponse, completion, path=["response"])
 
-    @pytest.mark.skip(reason="Prism tests are disabled")
+    @pytest.mark.respx(base_url=base_url)
     @parametrize
-    async def test_streaming_response_create_overload_1(self, async_client: AsyncLlamaAPIClient) -> None:
+    async def test_streaming_response_create_overload_1(
+        self, async_client: AsyncLlamaAPIClient, respx_mock: MockRouter
+    ) -> None:
+        respx_mock.post("/chat/completions").mock(
+            return_value=httpx.Response(
+                200, json={"completion_message": {"role": "assistant", "content": "hello"}, "id": "chatcmpl-123"}
+            )
+        )
         async with async_client.chat.completions.with_streaming_response.create(
             messages=[
                 {
@@ -301,9 +377,16 @@ class TestAsyncCompletions:
 
         assert cast(Any, response.is_closed) is True
 
-    @pytest.mark.skip(reason="Prism tests are disabled")
+    @pytest.mark.respx(base_url=base_url)
     @parametrize
-    async def test_method_create_overload_2(self, async_client: AsyncLlamaAPIClient) -> None:
+    async def test_method_create_overload_2(self, async_client: AsyncLlamaAPIClient, respx_mock: MockRouter) -> None:
+        respx_mock.post("/chat/completions").mock(
+            return_value=httpx.Response(
+                200,
+                headers={"content-type": "text/event-stream"},
+                content=b'data: {"event":{"event_type":"start","delta":{"type":"text","text":"hi"}}}\n\n',
+            )
+        )
         completion_stream = await async_client.chat.completions.create(
             messages=[
                 {
@@ -316,9 +399,18 @@ class TestAsyncCompletions:
         )
         await completion_stream.response.aclose()
 
-    @pytest.mark.skip(reason="Prism tests are disabled")
+    @pytest.mark.respx(base_url=base_url)
     @parametrize
-    async def test_method_create_with_all_params_overload_2(self, async_client: AsyncLlamaAPIClient) -> None:
+    async def test_method_create_with_all_params_overload_2(
+        self, async_client: AsyncLlamaAPIClient, respx_mock: MockRouter
+    ) -> None:
+        respx_mock.post("/chat/completions").mock(
+            return_value=httpx.Response(
+                200,
+                headers={"content-type": "text/event-stream"},
+                content=b'data: {"event":{"event_type":"start","delta":{"type":"text","text":"hi"}}}\n\n',
+            )
+        )
         completion_stream = await async_client.chat.completions.create(
             messages=[
                 {
@@ -356,9 +448,18 @@ class TestAsyncCompletions:
         )
         await completion_stream.response.aclose()
 
-    @pytest.mark.skip(reason="Prism tests are disabled")
+    @pytest.mark.respx(base_url=base_url)
     @parametrize
-    async def test_raw_response_create_overload_2(self, async_client: AsyncLlamaAPIClient) -> None:
+    async def test_raw_response_create_overload_2(
+        self, async_client: AsyncLlamaAPIClient, respx_mock: MockRouter
+    ) -> None:
+        respx_mock.post("/chat/completions").mock(
+            return_value=httpx.Response(
+                200,
+                headers={"content-type": "text/event-stream"},
+                content=b'data: {"event":{"event_type":"start","delta":{"type":"text","text":"hi"}}}\n\n',
+            )
+        )
         response = await async_client.chat.completions.with_raw_response.create(
             messages=[
                 {
@@ -374,9 +475,18 @@ class TestAsyncCompletions:
         stream = await response.parse()
         await stream.close()
 
-    @pytest.mark.skip(reason="Prism tests are disabled")
+    @pytest.mark.respx(base_url=base_url)
     @parametrize
-    async def test_streaming_response_create_overload_2(self, async_client: AsyncLlamaAPIClient) -> None:
+    async def test_streaming_response_create_overload_2(
+        self, async_client: AsyncLlamaAPIClient, respx_mock: MockRouter
+    ) -> None:
+        respx_mock.post("/chat/completions").mock(
+            return_value=httpx.Response(
+                200,
+                headers={"content-type": "text/event-stream"},
+                content=b'data: {"event":{"event_type":"start","delta":{"type":"text","text":"hi"}}}\n\n',
+            )
+        )
         async with async_client.chat.completions.with_streaming_response.create(
             messages=[
                 {

--- a/tests/api_resources/test_models.py
+++ b/tests/api_resources/test_models.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import os
 from typing import Any, cast
 
+import httpx
 import pytest
+from respx import MockRouter
 
 from tests.utils import assert_matches_type
 from llama_api_client import LlamaAPIClient, AsyncLlamaAPIClient
@@ -17,17 +19,29 @@ base_url = os.environ.get("TEST_API_BASE_URL", "http://127.0.0.1:4010")
 class TestModels:
     parametrize = pytest.mark.parametrize("client", [False, True], indirect=True, ids=["loose", "strict"])
 
-    @pytest.mark.skip(reason="Prism tests are disabled")
+    @pytest.mark.respx(base_url=base_url)
     @parametrize
-    def test_method_retrieve(self, client: LlamaAPIClient) -> None:
+    def test_method_retrieve(self, client: LlamaAPIClient, respx_mock: MockRouter) -> None:
+        respx_mock.get("/models/Llama-3.3-70B-Instruct").mock(
+            return_value=httpx.Response(
+                200,
+                json={"id": "Llama-3.3-70B-Instruct", "created": 1234567890, "object": "model", "owned_by": "meta"},
+            )
+        )
         model = client.models.retrieve(
             "Llama-3.3-70B-Instruct",
         )
         assert_matches_type(LlamaModel, model, path=["response"])
 
-    @pytest.mark.skip(reason="Prism tests are disabled")
+    @pytest.mark.respx(base_url=base_url)
     @parametrize
-    def test_raw_response_retrieve(self, client: LlamaAPIClient) -> None:
+    def test_raw_response_retrieve(self, client: LlamaAPIClient, respx_mock: MockRouter) -> None:
+        respx_mock.get("/models/Llama-3.3-70B-Instruct").mock(
+            return_value=httpx.Response(
+                200,
+                json={"id": "Llama-3.3-70B-Instruct", "created": 1234567890, "object": "model", "owned_by": "meta"},
+            )
+        )
         response = client.models.with_raw_response.retrieve(
             "Llama-3.3-70B-Instruct",
         )
@@ -37,9 +51,15 @@ class TestModels:
         model = response.parse()
         assert_matches_type(LlamaModel, model, path=["response"])
 
-    @pytest.mark.skip(reason="Prism tests are disabled")
+    @pytest.mark.respx(base_url=base_url)
     @parametrize
-    def test_streaming_response_retrieve(self, client: LlamaAPIClient) -> None:
+    def test_streaming_response_retrieve(self, client: LlamaAPIClient, respx_mock: MockRouter) -> None:
+        respx_mock.get("/models/Llama-3.3-70B-Instruct").mock(
+            return_value=httpx.Response(
+                200,
+                json={"id": "Llama-3.3-70B-Instruct", "created": 1234567890, "object": "model", "owned_by": "meta"},
+            )
+        )
         with client.models.with_streaming_response.retrieve(
             "Llama-3.3-70B-Instruct",
         ) as response:
@@ -51,7 +71,6 @@ class TestModels:
 
         assert cast(Any, response.is_closed) is True
 
-    @pytest.mark.skip(reason="Prism tests are disabled")
     @parametrize
     def test_path_params_retrieve(self, client: LlamaAPIClient) -> None:
         with pytest.raises(ValueError, match=r"Expected a non-empty value for `model` but received ''"):
@@ -59,15 +78,45 @@ class TestModels:
                 "",
             )
 
-    @pytest.mark.skip(reason="Prism tests are disabled")
+    @pytest.mark.respx(base_url=base_url)
     @parametrize
-    def test_method_list(self, client: LlamaAPIClient) -> None:
+    def test_method_list(self, client: LlamaAPIClient, respx_mock: MockRouter) -> None:
+        respx_mock.get("/models").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "data": [
+                        {
+                            "id": "Llama-3.3-70B-Instruct",
+                            "created": 1234567890,
+                            "object": "model",
+                            "owned_by": "meta",
+                        }
+                    ]
+                },
+            )
+        )
         model = client.models.list()
         assert_matches_type(ModelListResponse, model, path=["response"])
 
-    @pytest.mark.skip(reason="Prism tests are disabled")
+    @pytest.mark.respx(base_url=base_url)
     @parametrize
-    def test_raw_response_list(self, client: LlamaAPIClient) -> None:
+    def test_raw_response_list(self, client: LlamaAPIClient, respx_mock: MockRouter) -> None:
+        respx_mock.get("/models").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "data": [
+                        {
+                            "id": "Llama-3.3-70B-Instruct",
+                            "created": 1234567890,
+                            "object": "model",
+                            "owned_by": "meta",
+                        }
+                    ]
+                },
+            )
+        )
         response = client.models.with_raw_response.list()
 
         assert response.is_closed is True
@@ -75,9 +124,24 @@ class TestModels:
         model = response.parse()
         assert_matches_type(ModelListResponse, model, path=["response"])
 
-    @pytest.mark.skip(reason="Prism tests are disabled")
+    @pytest.mark.respx(base_url=base_url)
     @parametrize
-    def test_streaming_response_list(self, client: LlamaAPIClient) -> None:
+    def test_streaming_response_list(self, client: LlamaAPIClient, respx_mock: MockRouter) -> None:
+        respx_mock.get("/models").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "data": [
+                        {
+                            "id": "Llama-3.3-70B-Instruct",
+                            "created": 1234567890,
+                            "object": "model",
+                            "owned_by": "meta",
+                        }
+                    ]
+                },
+            )
+        )
         with client.models.with_streaming_response.list() as response:
             assert not response.is_closed
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"
@@ -93,17 +157,29 @@ class TestAsyncModels:
         "async_client", [False, True, {"http_client": "aiohttp"}], indirect=True, ids=["loose", "strict", "aiohttp"]
     )
 
-    @pytest.mark.skip(reason="Prism tests are disabled")
+    @pytest.mark.respx(base_url=base_url)
     @parametrize
-    async def test_method_retrieve(self, async_client: AsyncLlamaAPIClient) -> None:
+    async def test_method_retrieve(self, async_client: AsyncLlamaAPIClient, respx_mock: MockRouter) -> None:
+        respx_mock.get("/models/Llama-3.3-70B-Instruct").mock(
+            return_value=httpx.Response(
+                200,
+                json={"id": "Llama-3.3-70B-Instruct", "created": 1234567890, "object": "model", "owned_by": "meta"},
+            )
+        )
         model = await async_client.models.retrieve(
             "Llama-3.3-70B-Instruct",
         )
         assert_matches_type(LlamaModel, model, path=["response"])
 
-    @pytest.mark.skip(reason="Prism tests are disabled")
+    @pytest.mark.respx(base_url=base_url)
     @parametrize
-    async def test_raw_response_retrieve(self, async_client: AsyncLlamaAPIClient) -> None:
+    async def test_raw_response_retrieve(self, async_client: AsyncLlamaAPIClient, respx_mock: MockRouter) -> None:
+        respx_mock.get("/models/Llama-3.3-70B-Instruct").mock(
+            return_value=httpx.Response(
+                200,
+                json={"id": "Llama-3.3-70B-Instruct", "created": 1234567890, "object": "model", "owned_by": "meta"},
+            )
+        )
         response = await async_client.models.with_raw_response.retrieve(
             "Llama-3.3-70B-Instruct",
         )
@@ -113,9 +189,15 @@ class TestAsyncModels:
         model = await response.parse()
         assert_matches_type(LlamaModel, model, path=["response"])
 
-    @pytest.mark.skip(reason="Prism tests are disabled")
+    @pytest.mark.respx(base_url=base_url)
     @parametrize
-    async def test_streaming_response_retrieve(self, async_client: AsyncLlamaAPIClient) -> None:
+    async def test_streaming_response_retrieve(self, async_client: AsyncLlamaAPIClient, respx_mock: MockRouter) -> None:
+        respx_mock.get("/models/Llama-3.3-70B-Instruct").mock(
+            return_value=httpx.Response(
+                200,
+                json={"id": "Llama-3.3-70B-Instruct", "created": 1234567890, "object": "model", "owned_by": "meta"},
+            )
+        )
         async with async_client.models.with_streaming_response.retrieve(
             "Llama-3.3-70B-Instruct",
         ) as response:
@@ -127,7 +209,6 @@ class TestAsyncModels:
 
         assert cast(Any, response.is_closed) is True
 
-    @pytest.mark.skip(reason="Prism tests are disabled")
     @parametrize
     async def test_path_params_retrieve(self, async_client: AsyncLlamaAPIClient) -> None:
         with pytest.raises(ValueError, match=r"Expected a non-empty value for `model` but received ''"):
@@ -135,15 +216,45 @@ class TestAsyncModels:
                 "",
             )
 
-    @pytest.mark.skip(reason="Prism tests are disabled")
+    @pytest.mark.respx(base_url=base_url)
     @parametrize
-    async def test_method_list(self, async_client: AsyncLlamaAPIClient) -> None:
+    async def test_method_list(self, async_client: AsyncLlamaAPIClient, respx_mock: MockRouter) -> None:
+        respx_mock.get("/models").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "data": [
+                        {
+                            "id": "Llama-3.3-70B-Instruct",
+                            "created": 1234567890,
+                            "object": "model",
+                            "owned_by": "meta",
+                        }
+                    ]
+                },
+            )
+        )
         model = await async_client.models.list()
         assert_matches_type(ModelListResponse, model, path=["response"])
 
-    @pytest.mark.skip(reason="Prism tests are disabled")
+    @pytest.mark.respx(base_url=base_url)
     @parametrize
-    async def test_raw_response_list(self, async_client: AsyncLlamaAPIClient) -> None:
+    async def test_raw_response_list(self, async_client: AsyncLlamaAPIClient, respx_mock: MockRouter) -> None:
+        respx_mock.get("/models").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "data": [
+                        {
+                            "id": "Llama-3.3-70B-Instruct",
+                            "created": 1234567890,
+                            "object": "model",
+                            "owned_by": "meta",
+                        }
+                    ]
+                },
+            )
+        )
         response = await async_client.models.with_raw_response.list()
 
         assert response.is_closed is True
@@ -151,9 +262,24 @@ class TestAsyncModels:
         model = await response.parse()
         assert_matches_type(ModelListResponse, model, path=["response"])
 
-    @pytest.mark.skip(reason="Prism tests are disabled")
+    @pytest.mark.respx(base_url=base_url)
     @parametrize
-    async def test_streaming_response_list(self, async_client: AsyncLlamaAPIClient) -> None:
+    async def test_streaming_response_list(self, async_client: AsyncLlamaAPIClient, respx_mock: MockRouter) -> None:
+        respx_mock.get("/models").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "data": [
+                        {
+                            "id": "Llama-3.3-70B-Instruct",
+                            "created": 1234567890,
+                            "object": "model",
+                            "owned_by": "meta",
+                        }
+                    ]
+                },
+            )
+        )
         async with async_client.models.with_streaming_response.list() as response:
             assert not response.is_closed
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"

--- a/tests/api_resources/test_moderations.py
+++ b/tests/api_resources/test_moderations.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import os
 from typing import Any, cast
 
+import httpx
 import pytest
+from respx import MockRouter
 
 from tests.utils import assert_matches_type
 from llama_api_client import LlamaAPIClient, AsyncLlamaAPIClient
@@ -17,9 +19,15 @@ base_url = os.environ.get("TEST_API_BASE_URL", "http://127.0.0.1:4010")
 class TestModerations:
     parametrize = pytest.mark.parametrize("client", [False, True], indirect=True, ids=["loose", "strict"])
 
-    @pytest.mark.skip(reason="Prism tests are disabled")
+    @pytest.mark.respx(base_url=base_url)
     @parametrize
-    def test_method_create(self, client: LlamaAPIClient) -> None:
+    def test_method_create(self, client: LlamaAPIClient, respx_mock: MockRouter) -> None:
+        respx_mock.post("/moderations").mock(
+            return_value=httpx.Response(
+                200,
+                json={"model": "Llama-Guard", "results": [{"flagged": False, "flagged_categories": []}]},
+            )
+        )
         moderation = client.moderations.create(
             messages=[
                 {
@@ -30,9 +38,15 @@ class TestModerations:
         )
         assert_matches_type(ModerationCreateResponse, moderation, path=["response"])
 
-    @pytest.mark.skip(reason="Prism tests are disabled")
+    @pytest.mark.respx(base_url=base_url)
     @parametrize
-    def test_method_create_with_all_params(self, client: LlamaAPIClient) -> None:
+    def test_method_create_with_all_params(self, client: LlamaAPIClient, respx_mock: MockRouter) -> None:
+        respx_mock.post("/moderations").mock(
+            return_value=httpx.Response(
+                200,
+                json={"model": "Llama-Guard", "results": [{"flagged": False, "flagged_categories": []}]},
+            )
+        )
         moderation = client.moderations.create(
             messages=[
                 {
@@ -44,9 +58,15 @@ class TestModerations:
         )
         assert_matches_type(ModerationCreateResponse, moderation, path=["response"])
 
-    @pytest.mark.skip(reason="Prism tests are disabled")
+    @pytest.mark.respx(base_url=base_url)
     @parametrize
-    def test_raw_response_create(self, client: LlamaAPIClient) -> None:
+    def test_raw_response_create(self, client: LlamaAPIClient, respx_mock: MockRouter) -> None:
+        respx_mock.post("/moderations").mock(
+            return_value=httpx.Response(
+                200,
+                json={"model": "Llama-Guard", "results": [{"flagged": False, "flagged_categories": []}]},
+            )
+        )
         response = client.moderations.with_raw_response.create(
             messages=[
                 {
@@ -61,9 +81,15 @@ class TestModerations:
         moderation = response.parse()
         assert_matches_type(ModerationCreateResponse, moderation, path=["response"])
 
-    @pytest.mark.skip(reason="Prism tests are disabled")
+    @pytest.mark.respx(base_url=base_url)
     @parametrize
-    def test_streaming_response_create(self, client: LlamaAPIClient) -> None:
+    def test_streaming_response_create(self, client: LlamaAPIClient, respx_mock: MockRouter) -> None:
+        respx_mock.post("/moderations").mock(
+            return_value=httpx.Response(
+                200,
+                json={"model": "Llama-Guard", "results": [{"flagged": False, "flagged_categories": []}]},
+            )
+        )
         with client.moderations.with_streaming_response.create(
             messages=[
                 {
@@ -86,9 +112,15 @@ class TestAsyncModerations:
         "async_client", [False, True, {"http_client": "aiohttp"}], indirect=True, ids=["loose", "strict", "aiohttp"]
     )
 
-    @pytest.mark.skip(reason="Prism tests are disabled")
+    @pytest.mark.respx(base_url=base_url)
     @parametrize
-    async def test_method_create(self, async_client: AsyncLlamaAPIClient) -> None:
+    async def test_method_create(self, async_client: AsyncLlamaAPIClient, respx_mock: MockRouter) -> None:
+        respx_mock.post("/moderations").mock(
+            return_value=httpx.Response(
+                200,
+                json={"model": "Llama-Guard", "results": [{"flagged": False, "flagged_categories": []}]},
+            )
+        )
         moderation = await async_client.moderations.create(
             messages=[
                 {
@@ -99,9 +131,17 @@ class TestAsyncModerations:
         )
         assert_matches_type(ModerationCreateResponse, moderation, path=["response"])
 
-    @pytest.mark.skip(reason="Prism tests are disabled")
+    @pytest.mark.respx(base_url=base_url)
     @parametrize
-    async def test_method_create_with_all_params(self, async_client: AsyncLlamaAPIClient) -> None:
+    async def test_method_create_with_all_params(
+        self, async_client: AsyncLlamaAPIClient, respx_mock: MockRouter
+    ) -> None:
+        respx_mock.post("/moderations").mock(
+            return_value=httpx.Response(
+                200,
+                json={"model": "Llama-Guard", "results": [{"flagged": False, "flagged_categories": []}]},
+            )
+        )
         moderation = await async_client.moderations.create(
             messages=[
                 {
@@ -113,9 +153,15 @@ class TestAsyncModerations:
         )
         assert_matches_type(ModerationCreateResponse, moderation, path=["response"])
 
-    @pytest.mark.skip(reason="Prism tests are disabled")
+    @pytest.mark.respx(base_url=base_url)
     @parametrize
-    async def test_raw_response_create(self, async_client: AsyncLlamaAPIClient) -> None:
+    async def test_raw_response_create(self, async_client: AsyncLlamaAPIClient, respx_mock: MockRouter) -> None:
+        respx_mock.post("/moderations").mock(
+            return_value=httpx.Response(
+                200,
+                json={"model": "Llama-Guard", "results": [{"flagged": False, "flagged_categories": []}]},
+            )
+        )
         response = await async_client.moderations.with_raw_response.create(
             messages=[
                 {
@@ -130,9 +176,15 @@ class TestAsyncModerations:
         moderation = await response.parse()
         assert_matches_type(ModerationCreateResponse, moderation, path=["response"])
 
-    @pytest.mark.skip(reason="Prism tests are disabled")
+    @pytest.mark.respx(base_url=base_url)
     @parametrize
-    async def test_streaming_response_create(self, async_client: AsyncLlamaAPIClient) -> None:
+    async def test_streaming_response_create(self, async_client: AsyncLlamaAPIClient, respx_mock: MockRouter) -> None:
+        respx_mock.post("/moderations").mock(
+            return_value=httpx.Response(
+                200,
+                json={"model": "Llama-Guard", "results": [{"flagged": False, "flagged_categories": []}]},
+            )
+        )
         async with async_client.moderations.with_streaming_response.create(
             messages=[
                 {

--- a/tests/api_resources/test_uploads.py
+++ b/tests/api_resources/test_uploads.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import os
 from typing import Any, cast
 
+import httpx
 import pytest
+from respx import MockRouter
 
 from tests.utils import assert_matches_type
 from llama_api_client import LlamaAPIClient, AsyncLlamaAPIClient
@@ -21,9 +23,21 @@ base_url = os.environ.get("TEST_API_BASE_URL", "http://127.0.0.1:4010")
 class TestUploads:
     parametrize = pytest.mark.parametrize("client", [False, True], indirect=True, ids=["loose", "strict"])
 
-    @pytest.mark.skip(reason="Prism tests are disabled")
+    @pytest.mark.respx(base_url=base_url)
     @parametrize
-    def test_method_create(self, client: LlamaAPIClient) -> None:
+    def test_method_create(self, client: LlamaAPIClient, respx_mock: MockRouter) -> None:
+        respx_mock.post("/uploads").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "id": "upload_123",
+                    "bytes": 0,
+                    "filename": "filename",
+                    "mime_type": "image/jpeg",
+                    "purpose": "attachment",
+                },
+            )
+        )
         upload = client.uploads.create(
             bytes=0,
             filename="filename",
@@ -32,9 +46,21 @@ class TestUploads:
         )
         assert_matches_type(UploadCreateResponse, upload, path=["response"])
 
-    @pytest.mark.skip(reason="Prism tests are disabled")
+    @pytest.mark.respx(base_url=base_url)
     @parametrize
-    def test_method_create_with_all_params(self, client: LlamaAPIClient) -> None:
+    def test_method_create_with_all_params(self, client: LlamaAPIClient, respx_mock: MockRouter) -> None:
+        respx_mock.post("/uploads").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "id": "upload_123",
+                    "bytes": 0,
+                    "filename": "filename",
+                    "mime_type": "image/jpeg",
+                    "purpose": "attachment",
+                },
+            )
+        )
         upload = client.uploads.create(
             bytes=0,
             filename="filename",
@@ -44,9 +70,21 @@ class TestUploads:
         )
         assert_matches_type(UploadCreateResponse, upload, path=["response"])
 
-    @pytest.mark.skip(reason="Prism tests are disabled")
+    @pytest.mark.respx(base_url=base_url)
     @parametrize
-    def test_raw_response_create(self, client: LlamaAPIClient) -> None:
+    def test_raw_response_create(self, client: LlamaAPIClient, respx_mock: MockRouter) -> None:
+        respx_mock.post("/uploads").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "id": "upload_123",
+                    "bytes": 0,
+                    "filename": "filename",
+                    "mime_type": "image/jpeg",
+                    "purpose": "attachment",
+                },
+            )
+        )
         response = client.uploads.with_raw_response.create(
             bytes=0,
             filename="filename",
@@ -59,9 +97,21 @@ class TestUploads:
         upload = response.parse()
         assert_matches_type(UploadCreateResponse, upload, path=["response"])
 
-    @pytest.mark.skip(reason="Prism tests are disabled")
+    @pytest.mark.respx(base_url=base_url)
     @parametrize
-    def test_streaming_response_create(self, client: LlamaAPIClient) -> None:
+    def test_streaming_response_create(self, client: LlamaAPIClient, respx_mock: MockRouter) -> None:
+        respx_mock.post("/uploads").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "id": "upload_123",
+                    "bytes": 0,
+                    "filename": "filename",
+                    "mime_type": "image/jpeg",
+                    "purpose": "attachment",
+                },
+            )
+        )
         with client.uploads.with_streaming_response.create(
             bytes=0,
             filename="filename",
@@ -76,26 +126,29 @@ class TestUploads:
 
         assert cast(Any, response.is_closed) is True
 
-    @pytest.mark.skip(reason="Prism tests are disabled")
+    @pytest.mark.respx(base_url=base_url)
     @parametrize
-    def test_method_get(self, client: LlamaAPIClient) -> None:
+    def test_method_get(self, client: LlamaAPIClient, respx_mock: MockRouter) -> None:
+        respx_mock.get("/uploads/upload_id").mock(return_value=httpx.Response(200, json={"upload_id": "upload_id"}))
         upload = client.uploads.get(
             upload_id="upload_id",
         )
         assert_matches_type(UploadGetResponse, upload, path=["response"])
 
-    @pytest.mark.skip(reason="Prism tests are disabled")
+    @pytest.mark.respx(base_url=base_url)
     @parametrize
-    def test_method_get_with_all_params(self, client: LlamaAPIClient) -> None:
+    def test_method_get_with_all_params(self, client: LlamaAPIClient, respx_mock: MockRouter) -> None:
+        respx_mock.get("/uploads/upload_id").mock(return_value=httpx.Response(200, json={"upload_id": "upload_id"}))
         upload = client.uploads.get(
             upload_id="upload_id",
             x_api_version="1.0.0",
         )
         assert_matches_type(UploadGetResponse, upload, path=["response"])
 
-    @pytest.mark.skip(reason="Prism tests are disabled")
+    @pytest.mark.respx(base_url=base_url)
     @parametrize
-    def test_raw_response_get(self, client: LlamaAPIClient) -> None:
+    def test_raw_response_get(self, client: LlamaAPIClient, respx_mock: MockRouter) -> None:
+        respx_mock.get("/uploads/upload_id").mock(return_value=httpx.Response(200, json={"upload_id": "upload_id"}))
         response = client.uploads.with_raw_response.get(
             upload_id="upload_id",
         )
@@ -105,9 +158,10 @@ class TestUploads:
         upload = response.parse()
         assert_matches_type(UploadGetResponse, upload, path=["response"])
 
-    @pytest.mark.skip(reason="Prism tests are disabled")
+    @pytest.mark.respx(base_url=base_url)
     @parametrize
-    def test_streaming_response_get(self, client: LlamaAPIClient) -> None:
+    def test_streaming_response_get(self, client: LlamaAPIClient, respx_mock: MockRouter) -> None:
+        respx_mock.get("/uploads/upload_id").mock(return_value=httpx.Response(200, json={"upload_id": "upload_id"}))
         with client.uploads.with_streaming_response.get(
             upload_id="upload_id",
         ) as response:
@@ -119,7 +173,6 @@ class TestUploads:
 
         assert cast(Any, response.is_closed) is True
 
-    @pytest.mark.skip(reason="Prism tests are disabled")
     @parametrize
     def test_path_params_get(self, client: LlamaAPIClient) -> None:
         with pytest.raises(ValueError, match=r"Expected a non-empty value for `upload_id` but received ''"):
@@ -127,18 +180,20 @@ class TestUploads:
                 upload_id="",
             )
 
-    @pytest.mark.skip(reason="Prism tests are disabled")
+    @pytest.mark.respx(base_url=base_url)
     @parametrize
-    def test_method_part(self, client: LlamaAPIClient) -> None:
+    def test_method_part(self, client: LlamaAPIClient, respx_mock: MockRouter) -> None:
+        respx_mock.post("/uploads/upload_id").mock(return_value=httpx.Response(200, json={"upload_id": "upload_id"}))
         upload = client.uploads.part(
             upload_id="upload_id",
             data=b"raw file contents",
         )
         assert_matches_type(UploadPartResponse, upload, path=["response"])
 
-    @pytest.mark.skip(reason="Prism tests are disabled")
+    @pytest.mark.respx(base_url=base_url)
     @parametrize
-    def test_method_part_with_all_params(self, client: LlamaAPIClient) -> None:
+    def test_method_part_with_all_params(self, client: LlamaAPIClient, respx_mock: MockRouter) -> None:
+        respx_mock.post("/uploads/upload_id").mock(return_value=httpx.Response(200, json={"upload_id": "upload_id"}))
         upload = client.uploads.part(
             upload_id="upload_id",
             data=b"raw file contents",
@@ -147,9 +202,10 @@ class TestUploads:
         )
         assert_matches_type(UploadPartResponse, upload, path=["response"])
 
-    @pytest.mark.skip(reason="Prism tests are disabled")
+    @pytest.mark.respx(base_url=base_url)
     @parametrize
-    def test_raw_response_part(self, client: LlamaAPIClient) -> None:
+    def test_raw_response_part(self, client: LlamaAPIClient, respx_mock: MockRouter) -> None:
+        respx_mock.post("/uploads/upload_id").mock(return_value=httpx.Response(200, json={"upload_id": "upload_id"}))
         response = client.uploads.with_raw_response.part(
             upload_id="upload_id",
             data=b"raw file contents",
@@ -160,9 +216,10 @@ class TestUploads:
         upload = response.parse()
         assert_matches_type(UploadPartResponse, upload, path=["response"])
 
-    @pytest.mark.skip(reason="Prism tests are disabled")
+    @pytest.mark.respx(base_url=base_url)
     @parametrize
-    def test_streaming_response_part(self, client: LlamaAPIClient) -> None:
+    def test_streaming_response_part(self, client: LlamaAPIClient, respx_mock: MockRouter) -> None:
+        respx_mock.post("/uploads/upload_id").mock(return_value=httpx.Response(200, json={"upload_id": "upload_id"}))
         with client.uploads.with_streaming_response.part(
             upload_id="upload_id",
             data=b"raw file contents",
@@ -175,7 +232,6 @@ class TestUploads:
 
         assert cast(Any, response.is_closed) is True
 
-    @pytest.mark.skip(reason="Prism tests are disabled")
     @parametrize
     def test_path_params_part(self, client: LlamaAPIClient) -> None:
         with pytest.raises(ValueError, match=r"Expected a non-empty value for `upload_id` but received ''"):
@@ -190,9 +246,21 @@ class TestAsyncUploads:
         "async_client", [False, True, {"http_client": "aiohttp"}], indirect=True, ids=["loose", "strict", "aiohttp"]
     )
 
-    @pytest.mark.skip(reason="Prism tests are disabled")
+    @pytest.mark.respx(base_url=base_url)
     @parametrize
-    async def test_method_create(self, async_client: AsyncLlamaAPIClient) -> None:
+    async def test_method_create(self, async_client: AsyncLlamaAPIClient, respx_mock: MockRouter) -> None:
+        respx_mock.post("/uploads").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "id": "upload_123",
+                    "bytes": 0,
+                    "filename": "filename",
+                    "mime_type": "image/jpeg",
+                    "purpose": "attachment",
+                },
+            )
+        )
         upload = await async_client.uploads.create(
             bytes=0,
             filename="filename",
@@ -201,9 +269,23 @@ class TestAsyncUploads:
         )
         assert_matches_type(UploadCreateResponse, upload, path=["response"])
 
-    @pytest.mark.skip(reason="Prism tests are disabled")
+    @pytest.mark.respx(base_url=base_url)
     @parametrize
-    async def test_method_create_with_all_params(self, async_client: AsyncLlamaAPIClient) -> None:
+    async def test_method_create_with_all_params(
+        self, async_client: AsyncLlamaAPIClient, respx_mock: MockRouter
+    ) -> None:
+        respx_mock.post("/uploads").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "id": "upload_123",
+                    "bytes": 0,
+                    "filename": "filename",
+                    "mime_type": "image/jpeg",
+                    "purpose": "attachment",
+                },
+            )
+        )
         upload = await async_client.uploads.create(
             bytes=0,
             filename="filename",
@@ -213,9 +295,21 @@ class TestAsyncUploads:
         )
         assert_matches_type(UploadCreateResponse, upload, path=["response"])
 
-    @pytest.mark.skip(reason="Prism tests are disabled")
+    @pytest.mark.respx(base_url=base_url)
     @parametrize
-    async def test_raw_response_create(self, async_client: AsyncLlamaAPIClient) -> None:
+    async def test_raw_response_create(self, async_client: AsyncLlamaAPIClient, respx_mock: MockRouter) -> None:
+        respx_mock.post("/uploads").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "id": "upload_123",
+                    "bytes": 0,
+                    "filename": "filename",
+                    "mime_type": "image/jpeg",
+                    "purpose": "attachment",
+                },
+            )
+        )
         response = await async_client.uploads.with_raw_response.create(
             bytes=0,
             filename="filename",
@@ -228,9 +322,21 @@ class TestAsyncUploads:
         upload = await response.parse()
         assert_matches_type(UploadCreateResponse, upload, path=["response"])
 
-    @pytest.mark.skip(reason="Prism tests are disabled")
+    @pytest.mark.respx(base_url=base_url)
     @parametrize
-    async def test_streaming_response_create(self, async_client: AsyncLlamaAPIClient) -> None:
+    async def test_streaming_response_create(self, async_client: AsyncLlamaAPIClient, respx_mock: MockRouter) -> None:
+        respx_mock.post("/uploads").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "id": "upload_123",
+                    "bytes": 0,
+                    "filename": "filename",
+                    "mime_type": "image/jpeg",
+                    "purpose": "attachment",
+                },
+            )
+        )
         async with async_client.uploads.with_streaming_response.create(
             bytes=0,
             filename="filename",
@@ -245,26 +351,29 @@ class TestAsyncUploads:
 
         assert cast(Any, response.is_closed) is True
 
-    @pytest.mark.skip(reason="Prism tests are disabled")
+    @pytest.mark.respx(base_url=base_url)
     @parametrize
-    async def test_method_get(self, async_client: AsyncLlamaAPIClient) -> None:
+    async def test_method_get(self, async_client: AsyncLlamaAPIClient, respx_mock: MockRouter) -> None:
+        respx_mock.get("/uploads/upload_id").mock(return_value=httpx.Response(200, json={"upload_id": "upload_id"}))
         upload = await async_client.uploads.get(
             upload_id="upload_id",
         )
         assert_matches_type(UploadGetResponse, upload, path=["response"])
 
-    @pytest.mark.skip(reason="Prism tests are disabled")
+    @pytest.mark.respx(base_url=base_url)
     @parametrize
-    async def test_method_get_with_all_params(self, async_client: AsyncLlamaAPIClient) -> None:
+    async def test_method_get_with_all_params(self, async_client: AsyncLlamaAPIClient, respx_mock: MockRouter) -> None:
+        respx_mock.get("/uploads/upload_id").mock(return_value=httpx.Response(200, json={"upload_id": "upload_id"}))
         upload = await async_client.uploads.get(
             upload_id="upload_id",
             x_api_version="1.0.0",
         )
         assert_matches_type(UploadGetResponse, upload, path=["response"])
 
-    @pytest.mark.skip(reason="Prism tests are disabled")
+    @pytest.mark.respx(base_url=base_url)
     @parametrize
-    async def test_raw_response_get(self, async_client: AsyncLlamaAPIClient) -> None:
+    async def test_raw_response_get(self, async_client: AsyncLlamaAPIClient, respx_mock: MockRouter) -> None:
+        respx_mock.get("/uploads/upload_id").mock(return_value=httpx.Response(200, json={"upload_id": "upload_id"}))
         response = await async_client.uploads.with_raw_response.get(
             upload_id="upload_id",
         )
@@ -274,9 +383,10 @@ class TestAsyncUploads:
         upload = await response.parse()
         assert_matches_type(UploadGetResponse, upload, path=["response"])
 
-    @pytest.mark.skip(reason="Prism tests are disabled")
+    @pytest.mark.respx(base_url=base_url)
     @parametrize
-    async def test_streaming_response_get(self, async_client: AsyncLlamaAPIClient) -> None:
+    async def test_streaming_response_get(self, async_client: AsyncLlamaAPIClient, respx_mock: MockRouter) -> None:
+        respx_mock.get("/uploads/upload_id").mock(return_value=httpx.Response(200, json={"upload_id": "upload_id"}))
         async with async_client.uploads.with_streaming_response.get(
             upload_id="upload_id",
         ) as response:
@@ -288,7 +398,6 @@ class TestAsyncUploads:
 
         assert cast(Any, response.is_closed) is True
 
-    @pytest.mark.skip(reason="Prism tests are disabled")
     @parametrize
     async def test_path_params_get(self, async_client: AsyncLlamaAPIClient) -> None:
         with pytest.raises(ValueError, match=r"Expected a non-empty value for `upload_id` but received ''"):
@@ -296,18 +405,20 @@ class TestAsyncUploads:
                 upload_id="",
             )
 
-    @pytest.mark.skip(reason="Prism tests are disabled")
+    @pytest.mark.respx(base_url=base_url)
     @parametrize
-    async def test_method_part(self, async_client: AsyncLlamaAPIClient) -> None:
+    async def test_method_part(self, async_client: AsyncLlamaAPIClient, respx_mock: MockRouter) -> None:
+        respx_mock.post("/uploads/upload_id").mock(return_value=httpx.Response(200, json={"upload_id": "upload_id"}))
         upload = await async_client.uploads.part(
             upload_id="upload_id",
             data=b"raw file contents",
         )
         assert_matches_type(UploadPartResponse, upload, path=["response"])
 
-    @pytest.mark.skip(reason="Prism tests are disabled")
+    @pytest.mark.respx(base_url=base_url)
     @parametrize
-    async def test_method_part_with_all_params(self, async_client: AsyncLlamaAPIClient) -> None:
+    async def test_method_part_with_all_params(self, async_client: AsyncLlamaAPIClient, respx_mock: MockRouter) -> None:
+        respx_mock.post("/uploads/upload_id").mock(return_value=httpx.Response(200, json={"upload_id": "upload_id"}))
         upload = await async_client.uploads.part(
             upload_id="upload_id",
             data=b"raw file contents",
@@ -316,9 +427,10 @@ class TestAsyncUploads:
         )
         assert_matches_type(UploadPartResponse, upload, path=["response"])
 
-    @pytest.mark.skip(reason="Prism tests are disabled")
+    @pytest.mark.respx(base_url=base_url)
     @parametrize
-    async def test_raw_response_part(self, async_client: AsyncLlamaAPIClient) -> None:
+    async def test_raw_response_part(self, async_client: AsyncLlamaAPIClient, respx_mock: MockRouter) -> None:
+        respx_mock.post("/uploads/upload_id").mock(return_value=httpx.Response(200, json={"upload_id": "upload_id"}))
         response = await async_client.uploads.with_raw_response.part(
             upload_id="upload_id",
             data=b"raw file contents",
@@ -329,9 +441,10 @@ class TestAsyncUploads:
         upload = await response.parse()
         assert_matches_type(UploadPartResponse, upload, path=["response"])
 
-    @pytest.mark.skip(reason="Prism tests are disabled")
+    @pytest.mark.respx(base_url=base_url)
     @parametrize
-    async def test_streaming_response_part(self, async_client: AsyncLlamaAPIClient) -> None:
+    async def test_streaming_response_part(self, async_client: AsyncLlamaAPIClient, respx_mock: MockRouter) -> None:
+        respx_mock.post("/uploads/upload_id").mock(return_value=httpx.Response(200, json={"upload_id": "upload_id"}))
         async with async_client.uploads.with_streaming_response.part(
             upload_id="upload_id",
             data=b"raw file contents",
@@ -344,7 +457,6 @@ class TestAsyncUploads:
 
         assert cast(Any, response.is_closed) is True
 
-    @pytest.mark.skip(reason="Prism tests are disabled")
     @parametrize
     async def test_path_params_part(self, async_client: AsyncLlamaAPIClient) -> None:
         with pytest.raises(ValueError, match=r"Expected a non-empty value for `upload_id` but received ''"):


### PR DESCRIPTION
## Summary
- Removes all `@pytest.mark.skip(reason="Prism tests are disabled")` decorators from 4 API resource test files
- Adds `respx`-based HTTP mocking so tests run without a Prism mock server
- Covers all 4 API endpoints: chat completions, models, moderations, uploads
- Goes from 0 to 135 passing API resource tests

## Test plan
- [x] `pytest tests/api_resources/` — 135 passed, 30 skipped (aiohttp+respx incompatibility, expected)
- [x] Full test suite: 528 passed, 0 failed