### PR TITLE
fix(config): remove unsupported pytest-asyncio config key

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,7 +133,6 @@ testpaths = ["tests"]
 addopts = "--tb=short -n auto"
 xfail_strict = true
 asyncio_mode = "auto"
-asyncio_default_fixture_loop_scope = "session"
 filterwarnings = [
   "error"
 ]


### PR DESCRIPTION
## Summary
- Removes `asyncio_default_fixture_loop_scope = "session"` from `[tool.pytest.ini_options]`
- This key is not supported by the installed pytest-asyncio version and was silently ignored
- The `conftest.py` already handles session-scoped async loops via explicit `pytest.mark.asyncio(loop_scope="session")` marker application

## Test plan
- [x] Full test suite: 528 passed, 0 failed
- [x] Verified config loads cleanly (no `asyncio_default_fixture_loop_scope` warnings)