### PR TITLE
chore(deps): add version bounds to sniffio dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
   "typing-extensions>=4.10, <5",
   "anyio>=3.5.0, <5",
   "distro>=1.7.0, <2",
-  "sniffio",
+  "sniffio>=1.1, <2",
 ]
 
 requires-python = ">= 3.9"


### PR DESCRIPTION
## Summary
- Adds `>=1.1, <2` version bounds to the `sniffio` dependency
- Every other dependency in pyproject.toml has version constraints; this was the only one without bounds

## Test plan
- [x] Full test suite passes
- [x] Package imports successfully